### PR TITLE
Changed the property name in mapping response JSON

### DIFF
--- a/_posts/2015-11-29-elasticsearch-index-olusturmak.md
+++ b/_posts/2015-11-29-elasticsearch-index-olusturmak.md
@@ -72,7 +72,7 @@ otomatik yapacaktır.
       "mappings": {
           "user": {
             "properties": {
-               "test": {
+               "name": {
                   "type": "string"
                }
             }


### PR DESCRIPTION
If we run the query provided, the response JSON would provide the property `name`, instead of `test`. This PR simply aims to replace it.
